### PR TITLE
build: make build script cross-platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "rm -rf ./dist && tsc --p ./tsconfig.json &&  rm -rf ./dist/src && cp ./README.md dist/",
+    "build": "node scripts/build.js",
     "clear": "tsc --build --clean"
   },
   "dependencies": {

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,0 +1,41 @@
+const { copyFileSync, mkdirSync, rmSync } = require("node:fs");
+const { join } = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const rootDir = join(__dirname, "..");
+const distDir = join(rootDir, "dist");
+
+function run(command, args) {
+  const result = spawnSync(command, args, {
+    cwd: rootDir,
+    stdio: "inherit",
+    shell: false,
+  });
+
+  if (result.error) {
+    if (result.error.code === "ENOENT") {
+      console.error(
+        `Unable to find ${command}. Run npm install before building.`,
+      );
+    }
+    throw result.error;
+  }
+
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}
+
+rmSync(distDir, { recursive: true, force: true });
+let tscBin;
+try {
+  tscBin = require.resolve("typescript/bin/tsc", { paths: [rootDir] });
+} catch (error) {
+  console.error("Unable to find typescript. Run npm install before building.");
+  throw error;
+}
+
+run(process.execPath, [tscBin, "--p", "./tsconfig.json"]);
+rmSync(join(distDir, "src"), { recursive: true, force: true });
+mkdirSync(distDir, { recursive: true });
+copyFileSync(join(rootDir, "README.md"), join(distDir, "README.md"));


### PR DESCRIPTION
## Summary

- Replace the Unix-specific build command with a Node-based build script.
- Keep the existing build behavior: clean `dist`, run TypeScript, remove `dist/src`, and copy `README.md` into `dist`.
- Invoke TypeScript through the local `typescript/bin/tsc` entrypoint so the build does not depend on platform-specific shell commands like `rm` or `cp`.

## Verification

- `npm install --no-package-lock --ignore-scripts`
- `npm run build`