### PR TITLE
fix: sync SDK version headers with package version

### DIFF
--- a/src/lib/commerce-resource.ts
+++ b/src/lib/commerce-resource.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse, InternalAxiosRequestConfig } from 'axios'
+import { BOOTPAY_SDK_VERSION } from './sdk-version'
 
 export interface BootpayCommerceRestApiErrorResponse<T = any> {
     error_code?: number
@@ -31,7 +32,7 @@ export class BootpayCommerceResource {
     commerceConfiguration: CommerceConfiguration
     API_ENTRYPOINTS: CommerceEntrypoints
     apiVersion: string = '1.0.0'
-    sdkVersion: string = '1.0.0'
+    sdkVersion: string = BOOTPAY_SDK_VERSION
 
     constructor() {
         this.mode = 'production'

--- a/src/lib/resource.ts
+++ b/src/lib/resource.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios'
+import { BOOTPAY_SDK_VERSION } from './sdk-version'
 
 export interface BootpayRestApiErrorResponse<T = any> {
     error_code?: number
@@ -27,7 +28,7 @@ export class BootpayBackendNodejsResource {
     bootpayConfiguration: BootpayConfiguration
     API_ENTRYPOINTS: BootpayEntrypoints
     apiVersion: string = '5.0.0'
-    sdkVersion: string = '2.3.0'
+    sdkVersion: string = BOOTPAY_SDK_VERSION
 
     constructor() {
         this.mode                 = 'production'

--- a/src/lib/sdk-version.ts
+++ b/src/lib/sdk-version.ts
@@ -1,0 +1,3 @@
+import packageJson from '../../package.json'
+
+export const BOOTPAY_SDK_VERSION = packageJson.version

--- a/tests_basic_auth_product_info.mjs
+++ b/tests_basic_auth_product_info.mjs
@@ -32,6 +32,9 @@ function loadDotEnv() {
 
 loadDotEnv();
 
+const packageJson = JSON.parse(readFileSync(resolve(__dirname, 'package.json'), 'utf8'));
+const sdkVersion = packageJson.version;
+
 const env = (process.env.BOOTPAY_ENV || 'production').toLowerCase();
 const baseUrlMap = {
   production: 'https://api.bootapi.com/v1',
@@ -56,7 +59,7 @@ const res = await fetch(`${baseUrl}/products?page=1&limit=1`, {
     'Accept': 'application/json',
     'Content-Type': 'application/json',
     'bootpay_api_version': '5.0.0',
-    'bootpay_sdk_version': '5.0.0',
+    'bootpay_sdk_version': sdkVersion,
     'bootpay_sdk_type': '300'
   }
 });


### PR DESCRIPTION
## Summary
- read the SDK version from `package.json` through a shared `BOOTPAY_SDK_VERSION` constant
- use that shared SDK version in both the regular and Commerce request resources
- keep the manual Commerce smoke script's `bootpay_sdk_version` header aligned with the package version

## Verification
- `npm install --no-package-lock --ignore-scripts`
- `node .\node_modules\typescript\bin\tsc --p .\tsconfig.json`
- `node -e "const pkg=require('./dist/package.json'); const { BootpayBackendNodejsResource }=require('./dist/src/lib/resource'); const { BootpayCommerceResource }=require('./dist/src/lib/commerce-resource'); const main=new BootpayBackendNodejsResource(); const commerce=new BootpayCommerceResource(); if (main.sdkVersion !== pkg.version || commerce.sdkVersion !== pkg.version) { console.error({ expected: pkg.version, main: main.sdkVersion, commerce: commerce.sdkVersion }); process.exit(1); } console.log(JSON.stringify({ version: pkg.version, main: main.sdkVersion, commerce: commerce.sdkVersion }));"`
- `git diff --check`

`npm run build` was not used for the final check on this Windows machine because the current upstream build script still uses Unix shell commands (`rm`/`cp`). The TypeScript compile step above exercises the changed source directly.